### PR TITLE
Update link location for explanation for business presentation

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ EOS and others):
   off-chain **schema** and enhanced by *Simplicity
   language*
 
-More about these concepts can be read in [this presentation](https://github.com/LNP-BP/devcalls/blob/master/RGB%20%26%20Spectrum%20explanation%20for%20business.pdf).
+More about these concepts can be read in [this presentation](https://github.com/LNP-BP/FAQ/blob/master/Presentation%20slides/RGB%20%26%20Spectrum%20explanation%20for%20business.pdf).
 
 Briefly, RGB smart contracts operate with **client-side validation** paradigm,
 meaning that all the data is kept outside of the bitcoin transactions, i.e.


### PR DESCRIPTION
Deleted from devcalls (see https://github.com/LNP-BP/devcalls/commit/08038a846e5436b31ad383aa9694fdc6fd634c15), available in FAQ repo.